### PR TITLE
Add unit tests and migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,15 @@ DATABASE_URL=postgres://username:password@host:port/dbname sslmode=require go ru
 ```
 
 Without `DATABASE_URL`, the application continues to operate in memory only.
+
+## Database Migrations
+
+Schema changes are managed through simple SQL migration files stored in the
+`migrations` directory. To apply all migrations to the database specified by the
+`DATABASE_URL` environment variable run:
+
+```bash
+scripts/migrate.sh
+```
+
+The script applies each `*.sql` file in order using `psql`.

--- a/db_test.go
+++ b/db_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestLoadData(t *testing.T) {
+	resetState()
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock new: %v", err)
+	}
+	db = mockDB
+
+	invRows := sqlmock.NewRows([]string{"id", "name", "quantity"}).
+		AddRow(1, "Pen", 3)
+	mock.ExpectQuery("SELECT id, name, quantity FROM inventory").
+		WillReturnRows(invRows)
+
+	issRows := sqlmock.NewRows([]string{"item_id", "item_name", "person", "issued_by", "issued_at"}).
+		AddRow(1, "Pen", "Alice", "Bob", time.Now())
+	mock.ExpectQuery("SELECT item_id, item_name, person, issued_by, issued_at FROM issued").
+		WillReturnRows(issRows)
+
+	if err := loadData(); err != nil {
+		t.Fatalf("loadData: %v", err)
+	}
+	if len(items) != 1 || items[1].Name != "Pen" {
+		t.Fatalf("items not loaded: %+v", items)
+	}
+	if len(issued) != 1 || issued[0].Person != "Alice" {
+		t.Fatalf("issued not loaded: %+v", issued)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPopulateDB(t *testing.T) {
+	resetState()
+	items[1] = &InventoryItem{ID: 1, Name: "Pen", Quantity: 4}
+	issued = append(issued, IssuedItem{ItemID: 1, ItemName: "Pen", Person: "Alice", IssuedBy: "Bob", IssuedAt: time.Now()})
+
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock new: %v", err)
+	}
+	db = mockDB
+
+	mock.ExpectExec("INSERT INTO inventory").
+		WithArgs(1, "Pen", 4).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO issued").
+		WithArgs(1, "Pen", "Alice", "Bob", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := populateDB(); err != nil {
+		t.Fatalf("populateDB: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module supplyCloset
 go 1.24
 
 require github.com/lib/pq v1.10.9
+
+require github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func resetState() {
+	items = map[int]*InventoryItem{}
+	issued = []IssuedItem{}
+	nextID = 1
+	db = nil
+}
+
+func TestInventoryHandlerGet(t *testing.T) {
+	resetState()
+	items[1] = &InventoryItem{ID: 1, Name: "Pen", Quantity: 10}
+
+	req := httptest.NewRequest(http.MethodGet, "/inventory", nil)
+	rr := httptest.NewRecorder()
+
+	inventoryHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+
+	var resp []InventoryItem
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp) != 1 || resp[0].Name != "Pen" {
+		t.Fatalf("unexpected body: %+v", resp)
+	}
+}
+
+func TestInventoryHandlerPost(t *testing.T) {
+	resetState()
+
+	body := strings.NewReader(`{"name":"Marker","quantity":5}`)
+	req := httptest.NewRequest(http.MethodPost, "/inventory", body)
+	rr := httptest.NewRecorder()
+
+	inventoryHandler(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", rr.Code)
+	}
+	if len(items) != 1 {
+		t.Fatalf("item not added")
+	}
+	it := items[1]
+	if it.Name != "Marker" || it.Quantity != 5 {
+		t.Fatalf("unexpected item: %+v", it)
+	}
+}
+
+func TestIssueHandler(t *testing.T) {
+	resetState()
+	items[1] = &InventoryItem{ID: 1, Name: "Pen", Quantity: 2}
+
+	body := strings.NewReader(`{"itemId":1,"person":"Alice","issuedBy":"Bob"}`)
+	req := httptest.NewRequest(http.MethodPost, "/issue", body)
+	rr := httptest.NewRecorder()
+
+	issueHandler(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", rr.Code)
+	}
+	if items[1].Quantity != 1 {
+		t.Fatalf("quantity not decremented: %d", items[1].Quantity)
+	}
+	if len(issued) != 1 || issued[0].Person != "Alice" {
+		t.Fatalf("issued record not added")
+	}
+}
+
+func TestIssuedHandler(t *testing.T) {
+	resetState()
+	issued = append(issued, IssuedItem{ItemID: 1, ItemName: "Pen", Person: "Alice", IssuedBy: "Bob", IssuedAt: time.Now()})
+
+	req := httptest.NewRequest(http.MethodGet, "/issued", nil)
+	rr := httptest.NewRecorder()
+
+	issuedHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+	var resp []IssuedItem
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp) != 1 || resp[0].Person != "Alice" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}

--- a/migrations/001_create_tables.sql
+++ b/migrations/001_create_tables.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS inventory (
+    id INT PRIMARY KEY,
+    name TEXT NOT NULL,
+    quantity INT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS issued (
+    id SERIAL PRIMARY KEY,
+    item_id INT NOT NULL,
+    item_name TEXT NOT NULL,
+    person TEXT NOT NULL,
+    issued_by TEXT NOT NULL,
+    issued_at TIMESTAMPTZ NOT NULL
+);

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+if [ -z "$DATABASE_URL" ]; then
+    echo "DATABASE_URL not set" >&2
+    exit 1
+fi
+
+for file in $(ls migrations/*.sql | sort); do
+    echo "Applying $file"
+    psql "$DATABASE_URL" -f "$file"
+done


### PR DESCRIPTION
## Summary
- add handler and database unit tests using sqlmock
- create SQL migration and migration script
- document migrations in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686c0feeeee8832c87dd3f5c0e96e547