### PR TITLE
Clean leftover codex tokens

### DIFF
--- a/db.go
+++ b/db.go
@@ -15,14 +15,12 @@ func initDB(conn string) error {
 	}
 	// create new inventory table if it doesn't exist
 	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS inventory (
-        codex/modify-inventory-table-and-update-handlers
         id INT PRIMARY KEY,
         uniform_type TEXT,
         gender TEXT,
         item TEXT,
         style TEXT,
         size TEXT,
-         main
         quantity INT NOT NULL
     )`); err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -87,11 +87,9 @@ func inventoryHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		mu.Lock()
 		if db != nil {
-        codex/modify-inventory-table-and-update-handlers
 			if _, err := db.Exec(`INSERT INTO inventory (id, uniform_type, gender, item, style, size, quantity) VALUES ($1, $2, $3, $4, $5, $6, $7)
                                ON CONFLICT (id) DO UPDATE SET uniform_type=EXCLUDED.uniform_type, gender=EXCLUDED.gender, item=EXCLUDED.item, style=EXCLUDED.style, size=EXCLUDED.size, quantity=EXCLUDED.quantity`,
 				it.ID, it.UniformType, it.Gender, it.Item, it.Style, it.Size, it.Quantity); err != nil {
-       main
 				mu.Unlock()
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return


### PR DESCRIPTION
## Summary
- remove stray `codex/modify-inventory-table-and-update-handlers` comments
- delete errant `main` markers

## Testing
- `go test ./...` *(fails: InventoryItem.Name undefined)*

------
https://chatgpt.com/codex/tasks/task_e_686c15339d1c832cbcaa8f84c4736190