### PR TITLE
Align inventory name field

### DIFF
--- a/db.go
+++ b/db.go
@@ -15,28 +15,26 @@ func initDB(conn string) error {
 	}
 	// create new inventory table if it doesn't exist
 	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS inventory (
-        codex/modify-inventory-table-and-update-handlers
         id INT PRIMARY KEY,
         uniform_type TEXT,
         gender TEXT,
-        item TEXT,
+        name TEXT,
         style TEXT,
         size TEXT,
-         main
         quantity INT NOT NULL
     )`); err != nil {
 		return err
 	}
 	// handle upgrades from the old schema
-	// rename legacy "name" column to "item" if present
-	db.Exec(`ALTER TABLE inventory RENAME COLUMN name TO item`)
+	// rename legacy "item" column to "name" if present
+	db.Exec(`ALTER TABLE inventory RENAME COLUMN item TO name`)
 	// add any missing columns
 	alterCols := []string{
 		"ALTER TABLE inventory ADD COLUMN IF NOT EXISTS uniform_type TEXT",
 		"ALTER TABLE inventory ADD COLUMN IF NOT EXISTS gender TEXT",
 		"ALTER TABLE inventory ADD COLUMN IF NOT EXISTS style TEXT",
 		"ALTER TABLE inventory ADD COLUMN IF NOT EXISTS size TEXT",
-		"ALTER TABLE inventory ADD COLUMN IF NOT EXISTS item TEXT",
+		"ALTER TABLE inventory ADD COLUMN IF NOT EXISTS name TEXT",
 	}
 	for _, stmt := range alterCols {
 		if _, err := db.Exec(stmt); err != nil {
@@ -57,7 +55,7 @@ func initDB(conn string) error {
 }
 
 func loadData() error {
-	invRows, err := db.Query(`SELECT id, uniform_type, gender, item, style, size, quantity FROM inventory`)
+	invRows, err := db.Query(`SELECT id, uniform_type, gender, name, style, size, quantity FROM inventory`)
 	if err != nil {
 		return err
 	}
@@ -65,7 +63,7 @@ func loadData() error {
 	mu.Lock()
 	for invRows.Next() {
 		var it InventoryItem
-		if err := invRows.Scan(&it.ID, &it.UniformType, &it.Gender, &it.Item, &it.Style, &it.Size, &it.Quantity); err != nil {
+		if err := invRows.Scan(&it.ID, &it.UniformType, &it.Gender, &it.Name, &it.Style, &it.Size, &it.Quantity); err != nil {
 			mu.Unlock()
 			return err
 		}
@@ -93,9 +91,9 @@ func loadData() error {
 
 func populateDB() error {
 	for _, it := range items {
-		if _, err := db.Exec(`INSERT INTO inventory (id, uniform_type, gender, item, style, size, quantity) VALUES ($1, $2, $3, $4, $5, $6, $7)
-            ON CONFLICT (id) DO UPDATE SET uniform_type=EXCLUDED.uniform_type, gender=EXCLUDED.gender, item=EXCLUDED.item, style=EXCLUDED.style, size=EXCLUDED.size, quantity=EXCLUDED.quantity`,
-			it.ID, it.UniformType, it.Gender, it.Item, it.Style, it.Size, it.Quantity); err != nil {
+		if _, err := db.Exec(`INSERT INTO inventory (id, uniform_type, gender, name, style, size, quantity) VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (id) DO UPDATE SET uniform_type=EXCLUDED.uniform_type, gender=EXCLUDED.gender, name=EXCLUDED.name, style=EXCLUDED.style, size=EXCLUDED.size, quantity=EXCLUDED.quantity`,
+			it.ID, it.UniformType, it.Gender, it.Name, it.Style, it.Size, it.Quantity); err != nil {
 			return err
 		}
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -15,9 +15,9 @@ func TestLoadData(t *testing.T) {
 	}
 	db = mockDB
 
-	invRows := sqlmock.NewRows([]string{"id", "name", "quantity"}).
-		AddRow(1, "Pen", 3)
-	mock.ExpectQuery("SELECT id, name, quantity FROM inventory").
+	invRows := sqlmock.NewRows([]string{"id", "uniform_type", "gender", "name", "style", "size", "quantity"}).
+		AddRow(1, "", "", "Pen", "", "", 3)
+	mock.ExpectQuery("SELECT id, uniform_type, gender, name, style, size, quantity FROM inventory").
 		WillReturnRows(invRows)
 
 	issRows := sqlmock.NewRows([]string{"item_id", "item_name", "person", "issued_by", "issued_at"}).
@@ -51,7 +51,7 @@ func TestPopulateDB(t *testing.T) {
 	db = mockDB
 
 	mock.ExpectExec("INSERT INTO inventory").
-		WithArgs(1, "Pen", 4).
+		WithArgs(1, "", "", "Pen", "", "", 4).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO issued").
 		WithArgs(1, "Pen", "Alice", "Bob", sqlmock.AnyArg()).

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ type InventoryItem struct {
 	ID          int    `json:"id"`
 	UniformType string `json:"uniformType"`
 	Gender      string `json:"gender"`
-	Item        string `json:"item"`
+	Name        string `json:"name"`
 	Style       string `json:"style"`
 	Size        string `json:"size"`
 	Quantity    int    `json:"quantity"`
@@ -87,11 +87,9 @@ func inventoryHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		mu.Lock()
 		if db != nil {
-        codex/modify-inventory-table-and-update-handlers
-			if _, err := db.Exec(`INSERT INTO inventory (id, uniform_type, gender, item, style, size, quantity) VALUES ($1, $2, $3, $4, $5, $6, $7)
-                               ON CONFLICT (id) DO UPDATE SET uniform_type=EXCLUDED.uniform_type, gender=EXCLUDED.gender, item=EXCLUDED.item, style=EXCLUDED.style, size=EXCLUDED.size, quantity=EXCLUDED.quantity`,
-				it.ID, it.UniformType, it.Gender, it.Item, it.Style, it.Size, it.Quantity); err != nil {
-       main
+			if _, err := db.Exec(`INSERT INTO inventory (id, uniform_type, gender, name, style, size, quantity) VALUES ($1, $2, $3, $4, $5, $6, $7)
+                               ON CONFLICT (id) DO UPDATE SET uniform_type=EXCLUDED.uniform_type, gender=EXCLUDED.gender, name=EXCLUDED.name, style=EXCLUDED.style, size=EXCLUDED.size, quantity=EXCLUDED.quantity`,
+				it.ID, it.UniformType, it.Gender, it.Name, it.Style, it.Size, it.Quantity); err != nil {
 				mu.Unlock()
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
@@ -148,7 +146,7 @@ func issueHandler(w http.ResponseWriter, r *http.Request) {
 	item.Quantity--
 	iss := IssuedItem{
 		ItemID:   req.ItemID,
-		ItemName: item.Item,
+		ItemName: item.Name,
 		Person:   req.Person,
 		IssuedBy: req.IssuedBy,
 		IssuedAt: time.Now(),
@@ -162,7 +160,7 @@ func issueHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		if _, err := db.Exec(`INSERT INTO issued (item_id, item_name, person, issued_by, issued_at)
                        VALUES ($1, $2, $3, $4, $5)`,
-			req.ItemID, item.Item, req.Person, req.IssuedBy, iss.IssuedAt); err != nil {
+			req.ItemID, item.Name, req.Person, req.IssuedBy, iss.IssuedAt); err != nil {
 			mu.Unlock()
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
## Summary
- consolidate item description field to `Name`
- clean up migration helpers for new column name
- use `name` consistently in queries and handlers
- adjust DB mocks for new inventory columns

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686c153416e8832c8aa89229c6adb130